### PR TITLE
Fix missing parameter warning on MacOS

### DIFF
--- a/scripts/gitlogg-generate-log.sh
+++ b/scripts/gitlogg-generate-log.sh
@@ -14,8 +14,8 @@ yourpath='./_repos/'
 tempOutputFile='_tmp/gitlogg.tmp'
 
 # ensure file exists
-install -D /dev/null $tempOutputFile
-
+mkdir -p ${tempOutputFile%%.*}
+touch $tempOutputFile
 
 # name and path to this very script, for output message purposes
 thisFile='./scripts/gitlogg-generate-log.sh'


### PR DESCRIPTION
Don't have a Mac to test this on, but that should do it